### PR TITLE
replaced line 56 of CYRKeyboardButtonView.m

### DIFF
--- a/CYRKeyboardButton/CYRKeyboardButtonView.m
+++ b/CYRKeyboardButton/CYRKeyboardButtonView.m
@@ -53,7 +53,7 @@
 {
     CGRect frame = [UIScreen mainScreen].bounds;
     
-    if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
+    if ([UIScreen mainScreen].bounds.size.width > [UIScreen mainScreen].bounds.size.height) {
         frame = CGRectMake(0, 0, CGRectGetHeight(frame), CGRectGetWidth(frame));
     }
     


### PR DESCRIPTION
replaced line 56 of CYRKeyboardButtonView.m
changed from: if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
to : if ([UIScreen mainScreen].bounds.size.width > [UIScreen
mainScreen].bounds.size.height) {

When used in an iOS keyboard extension, the original line causes an error on compiling:
 'sharedApplication' is unavailable: not available on iOS (App Extension) - Use view controller based solutions where appropriate instead.

The new line still checks if the orientation is landscape, but sharedApplication is not used and compiles with no errors.
